### PR TITLE
✨ Python 3.13 Support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   python-packaging:
     name: 🐍 Packaging
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-packaging.yml@v1.2.1
 
   deploy:
     if: github.event_name == 'release' && github.event.action == 'published'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ concurrency:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-change-detection.yml@v1.2.1
 
   cpp-tests:
     name: 🇨‌ Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-ci.yml@v1.2.1
     with:
       cmake-args: ""
       cmake-args-ubuntu: -G Ninja
@@ -31,19 +31,21 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-cpp-linter.yml@v1.2.1
 
   python-tests:
     name: 🐍 Test
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-python-ci.yml@v1.2.1
+    with:
+      skip-testing-latest-python: true
 
   code-ql:
     name: 📝 CodeQL
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-code-ql)
-    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.1.5
+    uses: cda-tum/mqt-workflows/.github/workflows/reusable-code-ql.yml@v1.2.1
 
   required-checks-pass: # This job does nothing and is only used for branch protection
     name: 🚦 Check

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -16,7 +16,7 @@ if(BUILD_MQT_DDSIM_BINDINGS)
   endif()
 
   # add pybind11 library
-  find_package(pybind11 CONFIG REQUIRED)
+  find_package(pybind11 2.13 CONFIG REQUIRED)
 endif()
 
 # cmake-format: off

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 
 nox.options.sessions = ["lint", "tests"]
 
-PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
 # The following lists all the build requirements for building the package.
 # Note that this includes transitive build dependencies of package dependencies,
@@ -28,7 +28,7 @@ PYTHON_ALL_VERSIONS = ["3.8", "3.9", "3.10", "3.11", "3.12"]
 BUILD_REQUIREMENTS = [
     "scikit-build-core[pyproject]>=0.8.1",
     "setuptools_scm>=7",
-    "pybind11>=2.12",
+    "pybind11>=2.13",
     "wheel>=0.40",  # transitive dependency of pytest on Windows
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core>=0.8.1", "setuptools-scm>=7", "pybind11>=2.12"]
+requires = ["scikit-build-core>=0.8.1", "setuptools-scm>=7", "pybind11>=2.13"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Development Status :: 5 - Production/Stable",
 ]
 requires-python = ">=3.8"
@@ -261,8 +262,9 @@ build = "cp3*"
 skip = "*-musllinux_*"
 archs = "auto64"
 test-command = "python -c \"from mqt import ddsim\""
-test-skip = "cp38-macosx_arm64"
+test-skip = ["cp38-macosx_arm64", "cp313*"] # skip testing on Python 3.13 until our dependencies are ready
 build-frontend = "build[uv]"
+free-threaded-support = true
 
 [tool.cibuildwheel.linux]
 environment = { DEPLOY = "ON" }
@@ -271,6 +273,6 @@ environment = { DEPLOY = "ON" }
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.cibuildwheel.windows]
-before-build = "pip install delvewheel>=1.4.0"
+before-build = "pip install delvewheel>=1.7.3"
 repair-wheel-command = "delvewheel repair -v -w {dest_dir} {wheel} --namespace-pkg mqt"
 environment = { CMAKE_ARGS = "-T ClangCL" }

--- a/src/python/bindings.cpp
+++ b/src/python/bindings.cpp
@@ -194,7 +194,7 @@ py::class_<Sim> createSimulator(py::module_ m, const std::string& name) {
   return sim;
 }
 
-PYBIND11_MODULE(pyddsim, m) {
+PYBIND11_MODULE(pyddsim, m, py::mod_gil_not_used()) {
   m.doc() = "Python interface for the MQT DDSIM quantum circuit simulator";
 
   // Circuit Simulator


### PR DESCRIPTION
## Description

The (ABI-stable) release candidate for Python 3.13 just released and the newest MQT Workflows include an updated version of cibuildwheel that supports building wheels for it.

This PR enables regular Python 3.13 builds and also enables builds for the new free-threaded variant.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are related to it.
- [x] I have added appropriate tests and documentation.
- [x] I have made sure that all CI jobs on GitHub pass.
- [x] The pull request introduces no new warnings and follows the project's style guidelines.
