### PR TITLE
➕ Depend on `nlohmann_json` directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ➕ Depend on `nlohmann_json` directly instead of relying on `mqt-core` to
+  provide it ([#955]) ([**@denialhaag**])
 - ⬆️ Update `nanobind` to version 2.14.0 ([#953]) ([**@denialhaag**])
 - 🚚 Vendor density-matrix DD support used by the noise-aware simulators, as it
   will be removed from `mqt-core` in version 4.0.0 ([#940]) ([**@denialhaag**])
@@ -156,6 +158,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#955]: https://github.com/munich-quantum-toolkit/ddsim/pull/955
 [#953]: https://github.com/munich-quantum-toolkit/ddsim/pull/953
 [#944]: https://github.com/munich-quantum-toolkit/ddsim/pull/944
 [#940]: https://github.com/munich-quantum-toolkit/ddsim/pull/940

--- a/cmake/ExternalDependencies.cmake
+++ b/cmake/ExternalDependencies.cmake
@@ -49,6 +49,16 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS ${MQT_CORE_MINIMUM_VERSION})
 list(APPEND FETCH_PACKAGES mqt-core)
 
+set(JSON_VERSION
+    3.12.0
+    CACHE STRING "nlohmann_json version")
+set(JSON_URL https://github.com/nlohmann/json/releases/download/v${JSON_VERSION}/json.tar.xz)
+set(JSON_SystemInclude
+    ON
+    CACHE INTERNAL "Treat the library headers like system headers")
+FetchContent_Declare(nlohmann_json URL ${JSON_URL} FIND_PACKAGE_ARGS ${JSON_VERSION})
+list(APPEND FETCH_PACKAGES nlohmann_json)
+
 if(BUILD_MQT_DDSIM_TESTS)
   set(gtest_force_shared_crt
       ON

--- a/include/DensityUniqueTable.hpp
+++ b/include/DensityUniqueTable.hpp
@@ -29,7 +29,6 @@
 
 #include <cstddef>
 #include <functional>
-#include <nlohmann/json.hpp>
 #include <vector>
 
 namespace dd::ddsim {
@@ -92,8 +91,6 @@ public:
   [[nodiscard]] const auto& getStats() const noexcept { return stats; }
   [[nodiscard]] const dd::UniqueTableStatistics&
   getStats(std::size_t idx) const noexcept;
-  [[nodiscard]] nlohmann::basic_json<>
-  getStatsJson(bool includeIndividualTables = false) const;
   [[nodiscard]] std::size_t getNumEntries() const noexcept;
   [[nodiscard]] std::size_t countMarkedEntries() const noexcept;
   [[nodiscard]] bool possiblyNeedsCollection() const;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,9 +21,12 @@ if(NOT TARGET MQT::DDSim)
                              PUBLIC $<BUILD_INTERFACE:${MQT_DDSIM_INCLUDE_BUILD_DIR}>)
 
   # link to the MQT::Core and Taskflow libraries
+  #
+  # nlohmann_json is part of DDSIM's own public API (the path simulator configuration), so it is
+  # linked publicly here instead of being picked up transitively from MQT::Core.
   target_link_libraries(
     ${MQT_DDSIM_TARGET_NAME}
-    PUBLIC MQT::CoreDD MQT::CoreCircuitOptimizer Taskflow
+    PUBLIC MQT::CoreDD MQT::CoreCircuitOptimizer Taskflow nlohmann_json::nlohmann_json
     PRIVATE MQT::ProjectWarnings MQT::ProjectOptions)
 
   # the following sets the SYSTEM flag for the include dirs of the taskflow libs

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,10 +20,7 @@ if(NOT TARGET MQT::DDSim)
   target_include_directories(${MQT_DDSIM_TARGET_NAME}
                              PUBLIC $<BUILD_INTERFACE:${MQT_DDSIM_INCLUDE_BUILD_DIR}>)
 
-  # link to the MQT::Core and Taskflow libraries
-  #
-  # nlohmann_json is part of DDSIM's own public API (the path simulator configuration), so it is
-  # linked publicly here instead of being picked up transitively from MQT::Core.
+  # link to the MQT::Core, Taskflow, and nlohmann_json libraries
   target_link_libraries(
     ${MQT_DDSIM_TARGET_NAME}
     PUBLIC MQT::CoreDD MQT::CoreCircuitOptimizer Taskflow nlohmann_json::nlohmann_json

--- a/src/DensityUniqueTable.cpp
+++ b/src/DensityUniqueTable.cpp
@@ -14,11 +14,8 @@
 #include "dd/Node.hpp"
 #include "dd/statistics/UniqueTableStatistics.hpp"
 
-#include <algorithm>
 #include <cstddef>
-#include <nlohmann/json.hpp>
 #include <numeric>
-#include <string>
 
 namespace dd::ddsim {
 
@@ -101,39 +98,6 @@ void DensityUniqueTable::clear() {
 const dd::UniqueTableStatistics&
 DensityUniqueTable::getStats(const std::size_t idx) const noexcept {
   return stats.at(idx);
-}
-
-nlohmann::basic_json<>
-DensityUniqueTable::getStatsJson(const bool includeIndividualTables) const {
-  if (std::ranges::all_of(stats, [](const dd::UniqueTableStatistics& stat) {
-        return stat.peakNumEntries == 0U;
-      })) {
-    return "unused";
-  }
-
-  dd::UniqueTableStatistics totalStats;
-  for (const auto& stat : stats) {
-    totalStats.entrySize = std::max(totalStats.entrySize, stat.entrySize);
-    totalStats.numBuckets += stat.numBuckets;
-    totalStats.numEntries += stat.numEntries;
-    totalStats.peakNumEntries += stat.peakNumEntries;
-    totalStats.collisions += stat.collisions;
-    totalStats.hits += stat.hits;
-    totalStats.lookups += stat.lookups;
-    totalStats.inserts += stat.inserts;
-    totalStats.gcRuns = std::max(totalStats.gcRuns, stat.gcRuns);
-  }
-
-  nlohmann::basic_json<> j;
-  j["total"] = totalStats.json();
-  if (includeIndividualTables) {
-    std::size_t v = 0U;
-    for (const auto& stat : stats) {
-      j[std::to_string(v)] = stat.json();
-      ++v;
-    }
-  }
-  return j;
 }
 
 std::size_t DensityUniqueTable::getNumEntries() const noexcept {


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

MQT DDSIM exposes `nlohmann::json` in its own public API (`PathSimulator::Configuration::json`) and uses it in the CLI apps and tests, but never declared or linked the dependency. That only worked because MQT Core fetches `nlohmann_json` and propagates it publicly through `MQT::CoreDD`.

MQT Core is removing `nlohmann_json` from its public package contract (munich-quantum-toolkit/core#2099). This declares `nlohmann_json` in `cmake/ExternalDependencies.cmake` and links it publicly to the `mqt-ddsim` target so that DDSIM owns the dependency it actually uses.

It also removes `dd::ddsim::DensityUniqueTable::getStatsJson`, which came along with the vendored density-matrix DD support in #940. It duplicates `dd::UniqueTable::getStatsJson` from MQT Core, has no callers anywhere in the project, and is not reachable from the Python bindings — so rather than carrying a second JSON serializer through the Core cleanup, it is dropped.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ddsim/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
