### PR TITLE
💚 Run Doxygen in the Read the Docs `pre_build` job

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,13 @@ build:
     python: "3.14"
   apt_packages:
     - cmake
+    - doxygen
     - graphviz
-    - inkscape
+  jobs:
+    pre_build:
+      # Build the C++ API docs before Sphinx starts
+      - cd docs && mkdir -p _build/doxygen && doxygen
+      - cd docs && mkdir -p api/cpp && uv run --no-sync --no-dev breathe-apidoc -o api/cpp -m -f -g file _build/doxygen/xml/
 
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,8 +10,6 @@
 
 from __future__ import annotations
 
-import os
-import subprocess
 import warnings
 from importlib import metadata
 from pathlib import Path
@@ -68,7 +66,6 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinxcontrib.bibtex",
-    "sphinxcontrib.inkscapeconverter",
     "sphinxext.opengraph",
 ]
 
@@ -166,14 +163,6 @@ napoleon_numpy_docstring = False
 
 breathe_projects = {"mqt.ddsim": "_build/doxygen/xml"}
 breathe_default_project = "mqt.ddsim"
-
-read_the_docs_build = os.environ.get("READTHEDOCS", None) == "True"
-if read_the_docs_build:
-    subprocess.call("mkdir -p _build/doxygen && doxygen", shell=True)  # ruff:ignore[subprocess-popen-with-shell-equals-true, start-process-with-partial-path]
-    subprocess.call(  # ruff:ignore[subprocess-popen-with-shell-equals-true]
-        "mkdir -p api/cpp && breathe-apidoc -o api/cpp -m -f -g file _build/doxygen/xml/",  # ruff:ignore[start-process-with-partial-path]
-        shell=True,
-    )
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -350,9 +350,8 @@ docs = [
   "sphinx-autoapi>=3.6.0",
   "sphinx-copybutton>=0.5.2",
   "sphinx-design>=0.6.1",
-  "sphinx-llm",
+  "sphinx-llm>=0.4.1",
   "sphinxcontrib-bibtex>=2.6.5",
-  "sphinxcontrib-svg2pdfconverter>=1.3.0",
   "sphinxext-opengraph>=0.13.0",
   "qiskit[visualization]>=1.0.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1875,7 +1875,6 @@ docs = [
     { name = "sphinx-design", version = "0.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-llm" },
     { name = "sphinxcontrib-bibtex" },
-    { name = "sphinxcontrib-svg2pdfconverter" },
     { name = "sphinxext-opengraph" },
 ]
 test = [
@@ -1931,9 +1930,8 @@ docs = [
     { name = "sphinx-autoapi", specifier = ">=3.6.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
-    { name = "sphinx-llm" },
+    { name = "sphinx-llm", specifier = ">=0.4.1" },
     { name = "sphinxcontrib-bibtex", specifier = ">=2.6.5" },
-    { name = "sphinxcontrib-svg2pdfconverter", specifier = ">=1.3.0" },
     { name = "sphinxext-opengraph", specifier = ">=0.13.0" },
 ]
 test = [
@@ -3970,20 +3968,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
-]
-
-[[package]]
-name = "sphinxcontrib-svg2pdfconverter"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/05/11b12853b6a0398bd19d5464b68cb97dde21c354265ff2c1929f92ae03a9/sphinxcontrib_svg2pdfconverter-2.1.0.tar.gz", hash = "sha256:9756e82d5f3bf11629ffcbafb1f8a1092d3bb4789e33494032cdce9a9c8459d3", size = 6805, upload-time = "2026-03-05T18:23:44.74Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/7d/9b6b1ef6fe13bac6455d002ca4a626fac325cf94b4183f31cafe9b1ed17c/sphinxcontrib_svg2pdfconverter-2.1.0-py3-none-any.whl", hash = "sha256:805635ac274583e1606b0ec7fb21f16b69ca8ff223dd7e237d91127015628b0c", size = 9259, upload-time = "2026-03-05T18:23:43.662Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

`docs/conf.py` invoked Doxygen whenever `READTHEDOCS` was set, while the `sphinx_llm.txt` extension spawns a second, concurrent Sphinx process over the same source directory to build the Markdown files for `llms.txt`. That subprocess re-executes `conf.py`, thereby starting its own Doxygen run, which can truncate the XML files while Breathe is reading them in the primary build. In MQT Debugger, the same setup made the Read the Docs build fail with `breathe.parser.ParserError: no element found: line 1, column 0`, see [munich-quantum-toolkit/debugger#422](https://github.com/munich-quantum-toolkit/debugger/pull/422).

Doxygen and `breathe-apidoc` now run in the Read the Docs `pre_build` job, so they complete once before any Sphinx process starts.

The unused `inkscape` system package is removed as well, together with its Python counterpart: no PDF output is built, and the documentation contains no SVGs.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ddsim/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
