### PR TITLE
♻️ Own recursive unitary construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- 🚚 Move recursive unitary construction from MQT Core to MQT DDSIM ([#975])
+  ([**@simon1hofmann**])
+
 ## [2.5.0] - 2026-08-20
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#250)._
@@ -164,6 +169,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#975]: https://github.com/munich-quantum-toolkit/ddsim/pull/975
 [#966]: https://github.com/munich-quantum-toolkit/ddsim/pull/966
 [#955]: https://github.com/munich-quantum-toolkit/ddsim/pull/955
 [#954]: https://github.com/munich-quantum-toolkit/ddsim/pull/954

--- a/src/UnitarySimulator.cpp
+++ b/src/UnitarySimulator.cpp
@@ -17,6 +17,7 @@
 #include "dd/Node.hpp"
 #include "dd/Operations.hpp"
 #include "dd/Package.hpp"
+#include "ir/Permutation.hpp"
 #include "ir/QuantumComputation.hpp"
 #include "ir/operations/OpType.hpp"
 

--- a/src/UnitarySimulator.cpp
+++ b/src/UnitarySimulator.cpp
@@ -15,12 +15,65 @@
 #include "dd/DDpackageConfig.hpp"
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Node.hpp"
+#include "dd/Operations.hpp"
+#include "dd/Package.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
 
+#include <bit>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <utility>
+
+namespace {
+dd::MatrixDD buildFunctionalityPairwise(const qc::QuantumComputation& qc,
+                                        const std::size_t begin,
+                                        const std::size_t count,
+                                        qc::Permutation& permutation,
+                                        dd::Package& package) {
+  if (count == 1U) {
+    auto e = dd::Package::makeIdent();
+    if (const auto& op = qc.at(begin);
+        op->getType() == qc::OpType::SWAP && !op->isControlled()) {
+      const auto& targets = op->getTargets();
+      std::swap(permutation.at(targets[0U]), permutation.at(targets[1U]));
+    } else {
+      e = dd::getDD(*op, package, permutation);
+    }
+    package.incRef(e);
+    return e;
+  }
+
+  const auto leftCount = std::bit_floor(count - 1U);
+  const auto left =
+      buildFunctionalityPairwise(qc, begin, leftCount, permutation, package);
+  const auto right = buildFunctionalityPairwise(
+      qc, begin + leftCount, count - leftCount, permutation, package);
+  const auto result = package.multiply(right, left);
+  package.incRef(result);
+  package.decRef(left);
+  package.decRef(right);
+  package.garbageCollect();
+  return result;
+}
+
+dd::MatrixDD buildFunctionalityPairwise(const qc::QuantumComputation& qc,
+                                        dd::Package& package) {
+  if (qc.getNqubits() == 0U || qc.size() < 2U) {
+    return dd::buildFunctionality(qc, package);
+  }
+
+  auto permutation = qc.initialLayout;
+  auto e = buildFunctionalityPairwise(qc, 0U, qc.size(), permutation, package);
+
+  dd::changePermutation(e, permutation, qc.outputPermutation, package);
+  e = package.reduceAncillae(e, qc.getAncillary());
+  e = package.reduceGarbage(e, qc.getGarbage());
+  return e;
+}
+} // namespace
 
 void UnitarySimulator::construct() {
   // carry out actual computation
@@ -28,7 +81,7 @@ void UnitarySimulator::construct() {
   if (mode == Mode::Sequential) {
     e = dd::buildFunctionality(*qc, *dd);
   } else if (mode == Mode::Recursive) {
-    e = dd::buildFunctionalityRecursive(*qc, *dd);
+    e = buildFunctionalityPairwise(*qc, *dd);
   }
   auto end = std::chrono::steady_clock::now();
   constructionTime = std::chrono::duration<double>(end - start).count();

--- a/test/test_unitary_sim.cpp
+++ b/test/test_unitary_sim.cpp
@@ -11,6 +11,7 @@
 #include "UnitarySimulator.hpp"
 #include "ir/QuantumComputation.hpp"
 
+#include <cstddef>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
@@ -18,6 +19,46 @@
 #include <utility>
 
 using namespace qc::literals;
+
+namespace {
+void expectConstructionModesEquivalent(
+    const qc::QuantumComputation& quantumComputation) {
+  auto sequentialCircuit =
+      std::make_unique<qc::QuantumComputation>(quantumComputation);
+  auto recursiveCircuit =
+      std::make_unique<qc::QuantumComputation>(quantumComputation);
+  UnitarySimulator sequential(std::move(sequentialCircuit),
+                              UnitarySimulator::Mode::Sequential);
+  UnitarySimulator recursive(std::move(recursiveCircuit),
+                             UnitarySimulator::Mode::Recursive);
+
+  ASSERT_NO_THROW(sequential.construct());
+  ASSERT_NO_THROW(recursive.construct());
+
+  const auto sequentialMatrix =
+      sequential.getConstructedDD().getMatrix(quantumComputation.getNqubits());
+  const auto recursiveDD = recursive.getConstructedDD();
+  const auto recursiveMatrix =
+      recursiveDD.getMatrix(quantumComputation.getNqubits());
+  ASSERT_EQ(sequentialMatrix.size(), recursiveMatrix.size());
+  for (std::size_t row = 0U; row < sequentialMatrix.size(); ++row) {
+    ASSERT_EQ(sequentialMatrix[row].size(), recursiveMatrix[row].size());
+    for (std::size_t column = 0U; column < sequentialMatrix[row].size();
+         ++column) {
+      EXPECT_NEAR(sequentialMatrix[row][column].real(),
+                  recursiveMatrix[row][column].real(), 1e-12);
+      EXPECT_NEAR(sequentialMatrix[row][column].imag(),
+                  recursiveMatrix[row][column].imag(), 1e-12);
+    }
+  }
+
+  if (!recursiveDD.isTerminal()) {
+    const auto& roots = recursive.dd->getRootSet<dd::mNode>();
+    ASSERT_EQ(roots.size(), 1U);
+    EXPECT_EQ(roots.at(recursiveDD), 1U);
+  }
+}
+} // namespace
 
 TEST(UnitarySimTest, ConstructSimpleCircuitSequential) {
   auto quantumComputation = std::make_unique<qc::QuantumComputation>(3);
@@ -64,6 +105,48 @@ TEST(UnitarySimTest, ConstructSimpleCircuitRecursiveWithSeed) {
   const auto& e = ddsim.getConstructedDD();
   EXPECT_TRUE(e.p->e[0].isIdentity());
   EXPECT_TRUE(e.p->e[1].isIdentity());
+}
+
+TEST(UnitarySimTest, ConstructionModesEquivalentAtBoundaries) {
+  {
+    SCOPED_TRACE("empty circuit");
+    const qc::QuantumComputation quantumComputation(2);
+    expectConstructionModesEquivalent(quantumComputation);
+  }
+
+  {
+    SCOPED_TRACE("single virtual swap with matching output permutation");
+    qc::QuantumComputation quantumComputation(2);
+    quantumComputation.swap(0, 1);
+    quantumComputation.outputPermutation[0] = 1;
+    quantumComputation.outputPermutation[1] = 0;
+    expectConstructionModesEquivalent(quantumComputation);
+  }
+
+  {
+    SCOPED_TRACE("ancillary and garbage reduction");
+    qc::QuantumComputation quantumComputation(2);
+    quantumComputation.x(0);
+    quantumComputation.cx(0, 1);
+    quantumComputation.setLogicalQubitAncillary(1);
+    quantumComputation.setLogicalQubitGarbage(1);
+    expectConstructionModesEquivalent(quantumComputation);
+  }
+
+  {
+    SCOPED_TRACE("odd operation count with virtual swap and layouts");
+    qc::QuantumComputation quantumComputation(2);
+    quantumComputation.h(0);
+    quantumComputation.swap(0, 1);
+    quantumComputation.x(0);
+    quantumComputation.cx(0, 1);
+    quantumComputation.z(1);
+    quantumComputation.initialLayout[0] = 1;
+    quantumComputation.initialLayout[1] = 0;
+    quantumComputation.outputPermutation[0] = 1;
+    quantumComputation.outputPermutation[1] = 0;
+    expectConstructionModesEquivalent(quantumComputation);
+  }
 }
 
 TEST(UnitarySimTest, NonStandardOperation) {

--- a/test/test_unitary_sim.cpp
+++ b/test/test_unitary_sim.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "UnitarySimulator.hpp"
+#include "dd/Node.hpp"
 #include "ir/QuantumComputation.hpp"
 
 #include <cstddef>


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Keep `UnitarySimulatorMode::Recursive` working after MQT Core removes its simulator-specific recursive functionality builder in munich-quantum-toolkit/core#2102.

This change moves the pairwise recursive construction into a private DDSIM helper. It preserves operation order, virtual-swap permutation handling, ancilla/garbage reduction, and DD root ownership, while delegating empty and single-operation circuits to Core's sequential builder. Focused regression tests cover all of those boundaries.

This PR must merge before the companion munich-quantum-toolkit/core#2257. Codex materially assisted with the implementation, tests, final simplification review, validation, and PR text.

## Validation

- `uvx nox -s lint`
- All 5 `UnitarySimTest` cases
- Production `mqt-ddsim` build against the companion local MQT Core tree with the recursive API removed
- Full C++ suite: 116/117 tests pass; the sole failure is the unrelated, reproducible stochastic tolerance miss in `StochNoiseSimTest.CheckQubitOrder` (943 samples versus a 950 cutoff)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes. (No public DDSIM API or behavior changes.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed). (No DDSIM migration is needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. (Awaiting CI; see the known unrelated test failure above.)
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ddsim/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
