### PR TITLE
♻️ Migrate circuit normalization to Core v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ♻️ Migrate circuit normalization to the MQT Core v4 API ([#977])
+  ([**@simon1hofmann**])
 - 💥 Drop support for x86 macOS and stop publishing the respective wheels
   ([#976]) ([**@denialhaag**])
 - ⬆️ Raise the macOS deployment target to 13.3 to enable `std::format` in libc++
@@ -174,6 +176,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#977]: https://github.com/munich-quantum-toolkit/ddsim/pull/977
 [#976]: https://github.com/munich-quantum-toolkit/ddsim/pull/976
 [#975]: https://github.com/munich-quantum-toolkit/ddsim/pull/975
 [#966]: https://github.com/munich-quantum-toolkit/ddsim/pull/966

--- a/include/HybridSchrodingerFeynmanSimulator.hpp
+++ b/include/HybridSchrodingerFeynmanSimulator.hpp
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "CircuitSimulator.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/DDDefinitions.hpp"
 #include "dd/Node.hpp"
 #include "dd/Package.hpp"
@@ -38,9 +37,9 @@ public:
       const std::size_t nthreads_ = 2)
       : CircuitSimulator(std::move(qc_), approxInfo_), mode(mode_),
         nthreads(nthreads_) {
-    qc::CircuitOptimizer::flattenOperations(*qc);
+    qc->flattenOperations();
     // remove final measurements
-    qc::CircuitOptimizer::removeFinalMeasurements(*qc);
+    qc->removeFinalMeasurements();
   }
 
   explicit HybridSchrodingerFeynmanSimulator(
@@ -56,8 +55,8 @@ public:
       : CircuitSimulator(std::move(qc_), approxInfo_, seed_), mode(mode_),
         nthreads(nthreads_) {
     // remove final measurements
-    qc::CircuitOptimizer::flattenOperations(*qc);
-    qc::CircuitOptimizer::removeFinalMeasurements(*qc);
+    qc->flattenOperations();
+    qc->removeFinalMeasurements();
   }
 
   std::map<std::string, std::size_t> simulate(std::size_t shots) override;

--- a/include/PathSimulator.hpp
+++ b/include/PathSimulator.hpp
@@ -12,7 +12,6 @@
 
 #include "CircuitSimulator.hpp"
 #include "Simulator.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/Node.hpp"
 #include "ir/QuantumComputation.hpp"
 
@@ -167,7 +166,7 @@ public:
 
     // remove final measurements implement measurement support for task-based
     // simulation
-    qc::CircuitOptimizer::removeFinalMeasurements(*(CircuitSimulator::qc));
+    CircuitSimulator::qc->removeFinalMeasurements();
 
     // case distinction for the starting point of the alternating strategy
     if (configuration.startingPoint == 0) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -306,7 +306,6 @@ environment = { DEPLOY = "ON" }
 repair-wheel-command = """auditwheel repair -w {dest_dir} {wheel} \
 --exclude libmqt-core-ir.so.3.9 \
 --exclude libmqt-core-qasm.so.3.9 \
---exclude libmqt-core-circuit-optimizer.so.3.9 \
 --exclude libmqt-core-dd.so.3.9"""
 
 [tool.cibuildwheel.macos]
@@ -317,7 +316,6 @@ repair-wheel-command = "delocate-wheel --require-archs {delocate_archs} -w {dest
 repair-wheel-command = """delvewheel repair -w {dest_dir} {wheel} --namespace-pkg mqt \
 --exclude mqt-core-ir.dll \
 --exclude mqt-core-qasm.dll \
---exclude mqt-core-circuit-optimizer.dll \
 --exclude mqt-core-dd.dll"""
 
 [tool.uv]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT TARGET MQT::DDSim)
   # link to the MQT::Core, Taskflow, and nlohmann_json libraries
   target_link_libraries(
     ${MQT_DDSIM_TARGET_NAME}
-    PUBLIC MQT::CoreDD MQT::CoreCircuitOptimizer Taskflow nlohmann_json::nlohmann_json
+    PUBLIC MQT::CoreDD Taskflow nlohmann_json::nlohmann_json
     PRIVATE MQT::ProjectWarnings MQT::ProjectOptions)
 
   # the following sets the SYSTEM flag for the include dirs of the taskflow libs

--- a/src/UnitarySimulator.cpp
+++ b/src/UnitarySimulator.cpp
@@ -11,7 +11,6 @@
 #include "UnitarySimulator.hpp"
 
 #include "CircuitSimulator.hpp"
-#include "circuit_optimizer/CircuitOptimizer.hpp"
 #include "dd/DDpackageConfig.hpp"
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Node.hpp"
@@ -95,7 +94,7 @@ UnitarySimulator::UnitarySimulator(
                        dd::UNITARY_SIMULATOR_DD_PACKAGE_CONFIG),
       mode(simMode) {
   // remove final measurements
-  qc::CircuitOptimizer::removeFinalMeasurements(*qc);
+  qc->removeFinalMeasurements();
 }
 
 UnitarySimulator::UnitarySimulator(
@@ -110,5 +109,5 @@ UnitarySimulator::UnitarySimulator(
                        dd::UNITARY_SIMULATOR_DD_PACKAGE_CONFIG),
       mode(simMode) {
   // remove final measurements
-  qc::CircuitOptimizer::removeFinalMeasurements(*qc);
+  qc->removeFinalMeasurements();
 }


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Prepare DDSIM for the removal of `qc::CircuitOptimizer` in [MQT Core #2262](https://github.com/munich-quantum-toolkit/core/pull/2262):

- call `QuantumComputation::flattenOperations()` and `removeFinalMeasurements()` directly;
- remove the obsolete optimizer header and CMake target; and
- remove its Linux and Windows wheel-repair exclusions.

This intentionally leaves the MQT Core version requirement and `uv.lock` unchanged. The PR must remain a draft until Core v4 is released, at which point the dependency pin can be updated and the PR revalidated.

## Dependencies and merge order

This PR depends on Core #2262 and should merge only after the Core v4 release. Full validation against the Core v4 branch used a temporary out-of-tree `MQT::CoreAlgorithms` compatibility shim for that separate Core v4 migration; no shim or unrelated migration is part of this diff.

## Companion migration drafts

- Core: [munich-quantum-toolkit/core#2262](https://github.com/munich-quantum-toolkit/core/pull/2262)
- QCEC: [munich-quantum-toolkit/qcec#1042](https://github.com/munich-quantum-toolkit/qcec/pull/1042)
- QMAP: [munich-quantum-toolkit/qmap#1125](https://github.com/munich-quantum-toolkit/qmap/pull/1125)
- QuSAT: [munich-quantum-toolkit/qusat#514](https://github.com/munich-quantum-toolkit/qusat/pull/514)
- DDSIM: [munich-quantum-toolkit/ddsim#977](https://github.com/munich-quantum-toolkit/ddsim/pull/977)
- Debugger: [munich-quantum-toolkit/debugger#438](https://github.com/munich-quantum-toolkit/debugger/pull/438)

## Validation

- warning-clean build with `WARNINGS_AS_ERRORS=ON`
- 28/28 directly affected Hybrid, Unitary, and Path/TaskBased tests
- 116/117 full C++ tests; the sole failure is the unrelated stochastic `StochNoiseSimTest.CheckQubitOrder` threshold miss (943, minimum 950)
- 116/116 remaining tests when excluding that known stochastic case
- full `uvx nox -s lint`
- `git diff --check`

## AI assistance

Codex materially assisted with implementation, validation, review, and this pull request description. A human must review and understand the changes before marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable: no public DDSIM API changes.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed). (Not needed for DDSIM users.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Local Core v4 validation passes; CI requires the future Core v4 pin.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ddsim/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
