### PR TITLE
♻️ Delegate exact circuit execution to MQT Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🚚 Move the high-level `sample` and `simulate_statevector` helpers from MQT
+  Core to `mqt.ddsim`, and consolidate exact DD circuit execution in Core
+  ([#978]) ([**@simon1hofmann**])
 - ♻️ Migrate circuit normalization to the MQT Core v4 API ([#977])
   ([**@simon1hofmann**])
 - 💥 Drop support for x86 macOS and stop publishing the respective wheels
@@ -176,6 +179,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#978]: https://github.com/munich-quantum-toolkit/ddsim/pull/978
 [#977]: https://github.com/munich-quantum-toolkit/ddsim/pull/977
 [#976]: https://github.com/munich-quantum-toolkit/ddsim/pull/976
 [#975]: https://github.com/munich-quantum-toolkit/ddsim/pull/975

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,13 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### MQT Core v4 simulation helpers
+
+Import the high-level `sample` and `simulate_statevector` helpers from
+`mqt.ddsim` instead of `mqt.core.dd`. The package-aware Core DD primitives
+remain available for applications that manage their own `DDPackage` and input
+state.
+
 ### macOS support
 
 MQT DDSIM no longer supports x86 macOS. Use Apple silicon with macOS 13.3 or

--- a/docs/simulators/CircuitSimulator.md
+++ b/docs/simulators/CircuitSimulator.md
@@ -77,6 +77,25 @@ print(result)
 As expected, the output distribution is approximately 50% for the states
 $|00\rangle$ and $|11\rangle$ each.
 
+For one-off simulations, the package also provides convenience functions:
+
+```{code-cell} ipython3
+from mqt.core.ir import QuantumComputation
+
+from mqt.ddsim import sample, simulate_statevector
+
+counts = sample(qc, shots=1024)
+
+unitary_qc = QuantumComputation(2)
+unitary_qc.h(0)
+unitary_qc.cx(0, 1)
+statevector = simulate_statevector(unitary_qc)
+```
+
+The `sample` helper supports terminal and mid-circuit measurements, resets, and
+classical control. The `simulate_statevector` helper is intended for unitary
+circuits and returns an independent NumPy array.
+
 If we would like to obtain the full state vector of the quantum circuit, we can
 query it after the simulation as follows:
 

--- a/include/CircuitSimulator.hpp
+++ b/include/CircuitSimulator.hpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 struct ApproximationInfo {
   enum ApproximationStrategy : std::uint8_t { FidelityDriven, MemoryDriven };
@@ -130,10 +131,12 @@ protected:
   std::size_t approximationRuns{0};
   long double finalFidelity{1.0L};
 
+  std::map<std::string, std::size_t> simulateWithHooks(std::size_t shots);
+
   struct CircuitAnalysis {
     bool isDynamic = false;
     bool hasMeasurements = false;
-    std::map<qc::Qubit, size_t> measurementMap;
+    std::vector<std::pair<qc::Qubit, std::size_t>> terminalMeasurements;
   };
 
   CircuitAnalysis analyseCircuit();

--- a/include/DeterministicNoiseSimulator.hpp
+++ b/include/DeterministicNoiseSimulator.hpp
@@ -98,6 +98,10 @@ public:
         shots);
   }
 
+  std::map<std::string, std::size_t> simulate(std::size_t shots) override {
+    return simulateWithHooks(shots);
+  }
+
   void initializeSimulation(std::size_t nQubits) override;
   char measure(dd::Qubit i) override;
   void reset(qc::NonUnitaryOperation* nonUnitaryOp) override;
@@ -131,4 +135,5 @@ private:
   double measurementThreshold = 0.01;
   dd::ddsim::DensityDDPackage densityDD;
   dd::ddsim::DeterministicNoiseFunctionality deterministicNoiseFunctionality;
+  bool densityStateInitialized = false;
 };

--- a/python/mqt/ddsim/__init__.py
+++ b/python/mqt/ddsim/__init__.py
@@ -28,6 +28,7 @@ if sys.platform == "win32":  # ruff:ignore[non-empty-init-module] This is actual
     _dll_patch()
     del _dll_patch
 
+from ._simulation import sample, simulate_statevector
 from ._version import version as __version__
 from .provider import DDSIMProvider
 from .pyddsim import (
@@ -56,4 +57,6 @@ __all__ = [
     "UnitarySimulator",
     "UnitarySimulatorMode",
     "__version__",
+    "sample",
+    "simulate_statevector",
 ]

--- a/python/mqt/ddsim/_simulation.py
+++ b/python/mqt/ddsim/_simulation.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""High-level decision-diagram simulation helpers."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mqt.core.dd import DDPackage
+from mqt.core.dd import simulate as simulate_dd
+
+from .pyddsim import CircuitSimulator
+
+if TYPE_CHECKING:
+    import numpy as np
+    from mqt.core.ir import QuantumComputation
+    from numpy.typing import NDArray
+
+_MAX_SEED = (1 << 63) - 1
+
+
+def sample(qc: QuantumComputation, shots: int = 1024, seed: int = 0) -> dict[str, int]:
+    """Sample from the output distribution of a quantum computation.
+
+    Circuits with only terminal measurements are executed once. Circuits with
+    mid-circuit measurements, resets, or classical control are executed once
+    per shot.
+
+    Args:
+        qc: The quantum computation to simulate.
+        shots: The number of samples to draw.
+        seed: The non-negative signed 64-bit random seed. Zero selects a random
+            seed for compatibility with the former `mqt.core.dd.sample` helper.
+
+    Returns:
+        A histogram mapping big-endian measurement bitstrings to counts.
+    """
+    if not 0 <= seed <= _MAX_SEED:
+        msg = f"seed must be between 0 and {_MAX_SEED}"
+        raise ValueError(msg)
+
+    simulator = CircuitSimulator(qc, seed=-1 if seed == 0 else seed)
+    return simulator.simulate(shots)
+
+
+def simulate_statevector(qc: QuantumComputation) -> NDArray[np.complex128]:
+    """Simulate a unitary quantum computation and return its state vector.
+
+    Args:
+        qc: The unitary quantum computation to simulate.
+
+    Returns:
+        A copy of the final state vector.
+    """
+    package = DDPackage(qc.num_qubits)
+    final_state = simulate_dd(qc, package.zero_state(qc.num_qubits), package)
+    try:
+        return final_state.get_vector()
+    finally:
+        package.dec_ref_vec(final_state)

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -14,6 +14,7 @@
 #include "dd/FunctionalityConstruction.hpp"
 #include "dd/Node.hpp"
 #include "dd/Operations.hpp"
+#include "dd/Simulation.hpp"
 #include "dd/StateGeneration.hpp"
 #include "ir/Definitions.hpp"
 #include "ir/operations/IfElseOperation.hpp"
@@ -28,9 +29,34 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 std::map<std::string, std::size_t>
 CircuitSimulator::simulate(std::size_t shots) {
+  // Derived simulators customize the hook-based execution path. Approximation
+  // also depends on its established per-operation scheduling.
+  if (typeid(*this) != typeid(CircuitSimulator) ||
+      (approximationInfo.stepNumber > 0U &&
+       approximationInfo.stepFidelity < 1.0)) {
+    return simulateWithHooks(shots);
+  }
+
+  const auto& roots = dd->getRootSet<dd::vNode>();
+  const auto previousRoot = rootEdge;
+  const auto previousRootIsRegistered = roots.contains(previousRoot);
+
+  auto result =
+      dd::sample(*qc, dd::makeZeroState(qc->getNqubits(), *dd), *dd, shots, mt);
+  if (previousRootIsRegistered) {
+    dd->decRef(previousRoot);
+  }
+  rootEdge = result.state;
+  singleShots += result.executions;
+  return std::move(result.counts);
+}
+
+std::map<std::string, std::size_t>
+CircuitSimulator::simulateWithHooks(std::size_t shots) {
   const auto analysis = analyseCircuit();
 
   // easiest case: all gates are unitary --> simulate once and sample away on
@@ -53,7 +79,8 @@ CircuitSimulator::simulate(std::size_t shots) {
     for (const auto& [bit_string, count] : measureAllNonCollapsing(shots)) {
       std::string resultString(qc->getNcbits(), '0');
 
-      for (auto const& [qubit_index, bitIndex] : analysis.measurementMap) {
+      for (const auto& [qubit_index, bitIndex] :
+           analysis.terminalMeasurements) {
         resultString[cbits - bitIndex - 1] =
             bit_string[qubits - qubit_index - 1];
       }
@@ -102,7 +129,8 @@ auto CircuitSimulator::analyseCircuit() -> CircuitAnalysis {
       }
 
       for (unsigned int i = 0; i < quantum.size(); ++i) {
-        analysis.measurementMap[quantum.at(i)] = classic.at(i);
+        analysis.terminalMeasurements.emplace_back(quantum.at(i),
+                                                   classic.at(i));
       }
     }
 
@@ -126,6 +154,10 @@ CircuitSimulator::expectationValue(const qc::QuantumComputation& observable) {
 }
 
 void CircuitSimulator::initializeSimulation(const std::size_t nQubits) {
+  const auto& roots = dd->getRootSet<dd::vNode>();
+  if (roots.contains(rootEdge)) {
+    dd->decRef(rootEdge);
+  }
   rootEdge = dd::makeZeroState(static_cast<dd::Qubit>(nQubits), *dd);
 }
 

--- a/src/CircuitSimulator.cpp
+++ b/src/CircuitSimulator.cpp
@@ -29,7 +29,7 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
-#include <typeinfo>
+#include <utility>
 
 std::map<std::string, std::size_t>
 CircuitSimulator::simulate(std::size_t shots) {

--- a/src/DeterministicNoiseSimulator.cpp
+++ b/src/DeterministicNoiseSimulator.cpp
@@ -31,7 +31,12 @@ using CN = dd::ComplexNumbers;
 
 void DeterministicNoiseSimulator::initializeSimulation(
     const std::size_t nQubits) {
+  if (densityStateInitialized) {
+    dd::ddsim::DensityMatrixDD::alignDensityEdge(rootEdge);
+    densityDD.decRef(rootEdge);
+  }
   rootEdge = densityDD.makeZeroDensityOperator(static_cast<dd::Qubit>(nQubits));
+  densityStateInitialized = true;
 }
 
 void DeterministicNoiseSimulator::applyOperationToState(

--- a/src/DeterministicNoiseSimulator.cpp
+++ b/src/DeterministicNoiseSimulator.cpp
@@ -10,6 +10,7 @@
 
 #include "DeterministicNoiseSimulator.hpp"
 
+#include "DensityNode.hpp"
 #include "Simulator.hpp"
 #include "dd/ComplexNumbers.hpp"
 #include "dd/DDDefinitions.hpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@
 package_add_test(
   mqt-ddsim-test
   MQT::DDSim
+  test_circuit_execution.cpp
   test_circuit_sim.cpp
   test_shor_sim.cpp
   test_fast_shor_sim.cpp

--- a/test/python/simulator/test_standalone_simulator.py
+++ b/test/python/simulator/test_standalone_simulator.py
@@ -12,10 +12,11 @@ import pathlib
 import unittest
 
 import numpy as np
+import pytest
 from mqt.core import load
 from mqt.core.ir import QuantumComputation
 
-from mqt.ddsim import CircuitSimulator
+from mqt.ddsim import CircuitSimulator, sample, simulate_statevector
 
 
 class MQTStandaloneSimulatorTests(unittest.TestCase):
@@ -55,6 +56,34 @@ class MQTStandaloneSimulatorTests(unittest.TestCase):
         assert len(result.keys()) == self.nonzero_states_ghz
         assert "000" in result
         assert "111" in result
+
+    @staticmethod
+    def test_sampling_helper() -> None:
+        circ = QuantumComputation(1, 2)
+        circ.x(0)
+        circ.measure(0, 0)
+        circ.measure(0, 1)
+
+        assert sample(circ, shots=16, seed=1337) == {"11": 16}
+
+        with pytest.raises(ValueError, match="seed must be between 0 and"):
+            sample(circ, shots=16, seed=-1)
+
+    @staticmethod
+    def test_statevector_helper() -> None:
+        circ = QuantumComputation(1)
+        circ.x(0)
+        circ.gphase(np.pi / 2)
+
+        assert np.allclose(simulate_statevector(circ), np.array([0, 1j]))
+
+    @staticmethod
+    def test_statevector_helper_rejects_nonunitary_circuits() -> None:
+        circ = QuantumComputation(1, 1)
+        circ.measure(0, 0)
+
+        with pytest.raises(ValueError, match="DD for non-unitary operation not available"):
+            simulate_statevector(circ)
 
     def test_standalone_simple_approximation(self) -> None:
 

--- a/test/test_circuit_execution.cpp
+++ b/test/test_circuit_execution.cpp
@@ -13,7 +13,9 @@
 #include "dd/Node.hpp"
 #include "ir/Definitions.hpp"
 #include "ir/QuantumComputation.hpp"
+#include "ir/operations/NonUnitaryOperation.hpp"
 #include "ir/operations/OpType.hpp"
+#include "ir/operations/Operation.hpp"
 
 #include <cmath>
 #include <cstddef>
@@ -22,11 +24,14 @@
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace {
 
 class HookedCircuitSimulator final : public CircuitSimulator {
 public:
+  // Inherited constructors forward their arguments.
+  // NOLINTNEXTLINE(cppcoreguidelines-rvalue-reference-param-not-moved)
   using CircuitSimulator::CircuitSimulator;
 
   [[nodiscard]] bool operationHookWasCalled() const noexcept {

--- a/test/test_circuit_execution.cpp
+++ b/test/test_circuit_execution.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+ * Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Licensed under the MIT License
+ */
+
+#include "CircuitSimulator.hpp"
+#include "DeterministicNoiseSimulator.hpp"
+#include "dd/Node.hpp"
+#include "ir/Definitions.hpp"
+#include "ir/QuantumComputation.hpp"
+#include "ir/operations/OpType.hpp"
+
+#include <cmath>
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+class HookedCircuitSimulator final : public CircuitSimulator {
+public:
+  using CircuitSimulator::CircuitSimulator;
+
+  [[nodiscard]] bool operationHookWasCalled() const noexcept {
+    return hookWasCalled;
+  }
+
+protected:
+  void
+  applyOperationToState(std::unique_ptr<qc::Operation>& operation) override {
+    hookWasCalled = true;
+    CircuitSimulator::applyOperationToState(operation);
+  }
+
+private:
+  bool hookWasCalled = false;
+};
+
+} // namespace
+
+TEST(CircuitExecutionTest, RetainsCanonicalStateAfterVirtualSwap) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(2U, 2U);
+  circuit->x(0U);
+  circuit->swap(0U, 1U);
+  circuit->measure(0U, 0U);
+  circuit->measure(1U, 1U);
+  circuit->gphase(qc::PI_2);
+
+  CircuitSimulator simulator(std::move(circuit), 17U);
+  const auto counts = simulator.simulate(8U);
+
+  EXPECT_EQ(counts, (std::map<std::string, std::size_t>{{"10", 8U}}));
+  EXPECT_EQ(simulator.additionalStatistics().at("single_shots"), "1");
+  const auto amplitudes = simulator.getCurrentDD().getVector();
+  ASSERT_EQ(amplitudes.size(), 4U);
+  EXPECT_NEAR(amplitudes.at(2U).real(), 0., 1e-12);
+  EXPECT_NEAR(amplitudes.at(2U).imag(), 1., 1e-12);
+}
+
+TEST(CircuitExecutionTest, ExecutesDynamicMeasurementResetAndControl) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(2U, 2U);
+  circuit->x(0U);
+  circuit->swap(0U, 1U);
+  circuit->measure(1U, 0U);
+  circuit->reset(1U);
+  circuit->if_(qc::X, 0U, 0U);
+  circuit->measure(0U, 1U);
+
+  CircuitSimulator simulator(std::move(circuit), 17U);
+  const auto counts = simulator.simulate(8U);
+
+  EXPECT_EQ(counts, (std::map<std::string, std::size_t>{{"11", 8U}}));
+  EXPECT_EQ(simulator.additionalStatistics().at("single_shots"), "8");
+  const auto amplitudes = simulator.getCurrentDD().getVector();
+  ASSERT_EQ(amplitudes.size(), 4U);
+  EXPECT_NEAR(std::abs(amplitudes.at(1U)), 1., 1e-12);
+  const auto& roots = simulator.dd->getRootSet<dd::vNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.at(simulator.getCurrentDD()), 1U);
+}
+
+TEST(CircuitExecutionTest, ZeroShotsPreserveExecutionSemantics) {
+  auto staticCircuit = std::make_unique<qc::QuantumComputation>(1U);
+  staticCircuit->x(0U);
+  CircuitSimulator staticSimulator(std::move(staticCircuit), 0U);
+
+  EXPECT_TRUE(staticSimulator.simulate(0U).empty());
+  EXPECT_EQ(staticSimulator.additionalStatistics().at("single_shots"), "1");
+  EXPECT_NEAR(std::abs(staticSimulator.getCurrentDD().getVector().at(1U)), 1.,
+              1e-12);
+
+  auto dynamicCircuit = std::make_unique<qc::QuantumComputation>(1U, 1U);
+  dynamicCircuit->measure(0U, 0U);
+  dynamicCircuit->x(0U);
+  CircuitSimulator dynamicSimulator(std::move(dynamicCircuit), 0U);
+
+  EXPECT_TRUE(dynamicSimulator.simulate(0U).empty());
+  EXPECT_EQ(dynamicSimulator.additionalStatistics().at("single_shots"), "0");
+  EXPECT_NEAR(std::abs(dynamicSimulator.getCurrentDD().getVector().at(0U)), 1.,
+              1e-12);
+}
+
+TEST(CircuitExecutionTest, RepeatedCallsReuseRngWithoutLeakingRoots) {
+  const auto makeCircuit = [] {
+    auto circuit = std::make_unique<qc::QuantumComputation>(1U);
+    circuit->h(0U);
+    return circuit;
+  };
+
+  CircuitSimulator splitSimulator(makeCircuit(), 0U);
+  auto splitCounts = splitSimulator.simulate(17U);
+  for (const auto& [state, count] : splitSimulator.simulate(23U)) {
+    splitCounts[state] += count;
+  }
+
+  CircuitSimulator combinedSimulator(makeCircuit(), 0U);
+  const auto combinedCounts = combinedSimulator.simulate(40U);
+
+  EXPECT_EQ(splitCounts, combinedCounts);
+  EXPECT_EQ(splitSimulator.additionalStatistics().at("single_shots"), "2");
+  EXPECT_EQ(combinedSimulator.additionalStatistics().at("single_shots"), "1");
+
+  const auto& roots = splitSimulator.dd->getRootSet<dd::vNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.at(splitSimulator.getCurrentDD()), 1U);
+}
+
+TEST(CircuitExecutionTest, DynamicRepeatedCallsReuseRng) {
+  const auto makeCircuit = [] {
+    auto circuit = std::make_unique<qc::QuantumComputation>(1U, 1U);
+    circuit->h(0U);
+    circuit->measure(0U, 0U);
+    circuit->x(0U);
+    return circuit;
+  };
+
+  CircuitSimulator splitSimulator(makeCircuit(), 0U);
+  auto splitCounts = splitSimulator.simulate(17U);
+  for (const auto& [state, count] : splitSimulator.simulate(23U)) {
+    splitCounts[state] += count;
+  }
+
+  CircuitSimulator combinedSimulator(makeCircuit(), 0U);
+  const auto combinedCounts = combinedSimulator.simulate(40U);
+
+  EXPECT_EQ(splitCounts, combinedCounts);
+  EXPECT_EQ(splitSimulator.additionalStatistics().at("single_shots"), "40");
+  EXPECT_EQ(combinedSimulator.additionalStatistics().at("single_shots"), "40");
+}
+
+TEST(CircuitExecutionTest, FailedExecutionKeepsPreviousStateAndCanRetry) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(1U, 1U);
+  circuit->x(0U);
+  auto* mutableCircuit = circuit.get();
+  CircuitSimulator simulator(std::move(circuit), 17U);
+
+  EXPECT_EQ(simulator.simulate(1U),
+            (std::map<std::string, std::size_t>{{"1", 1U}}));
+  const auto previousState = simulator.getCurrentDD();
+
+  mutableCircuit->measure(0U, 0U);
+  auto& measurement = dynamic_cast<qc::NonUnitaryOperation&>(
+      *mutableCircuit->at(mutableCircuit->getNops() - 1U));
+  measurement.getClassics().clear();
+  EXPECT_THROW(static_cast<void>(simulator.simulate(1U)),
+               std::invalid_argument);
+
+  EXPECT_EQ(simulator.getCurrentDD(), previousState);
+  const auto& rootsAfterFailure = simulator.dd->getRootSet<dd::vNode>();
+  ASSERT_EQ(rootsAfterFailure.size(), 1U);
+  EXPECT_EQ(rootsAfterFailure.at(previousState), 1U);
+
+  measurement.getClassics().emplace_back(0U);
+  EXPECT_EQ(simulator.simulate(1U),
+            (std::map<std::string, std::size_t>{{"1", 1U}}));
+  const auto& rootsAfterRetry = simulator.dd->getRootSet<dd::vNode>();
+  ASSERT_EQ(rootsAfterRetry.size(), 1U);
+  EXPECT_EQ(rootsAfterRetry.at(simulator.getCurrentDD()), 1U);
+}
+
+TEST(CircuitExecutionTest, DerivedSimulatorKeepsExecutionHooks) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(1U, 2U);
+  circuit->x(0U);
+  circuit->measure(0U, 0U);
+  circuit->measure(0U, 1U);
+  HookedCircuitSimulator simulator(std::move(circuit), 17U);
+
+  EXPECT_EQ(simulator.simulate(1U),
+            (std::map<std::string, std::size_t>{{"11", 1U}}));
+  EXPECT_TRUE(simulator.operationHookWasCalled());
+}
+
+TEST(CircuitExecutionTest, ApproximationKeepsHookExecutionLoop) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(3U);
+  circuit->h(0U);
+  circuit->h(1U);
+  circuit->mcx(qc::Controls{qc::Control{0U}, qc::Control{1U}}, 2U);
+  circuit->i(1U);
+  circuit->i(1U);
+
+  CircuitSimulator simulator(
+      std::move(circuit),
+      ApproximationInfo(0.3, 1U, ApproximationInfo::FidelityDriven), 17U);
+  simulator.simulate(1U);
+
+  EXPECT_EQ(simulator.getActiveNodeCount(), 3U);
+  EXPECT_EQ(simulator.additionalStatistics().at("approximation_runs"), "1");
+  EXPECT_DOUBLE_EQ(
+      std::stod(simulator.additionalStatistics().at("final_fidelity")), 0.5);
+}
+
+TEST(CircuitExecutionTest, DeterministicNoiseKeepsDensityExecutionLoop) {
+  auto circuit = std::make_unique<qc::QuantumComputation>(2U, 2U);
+  circuit->x(0U);
+  circuit->x(1U);
+  circuit->reset(0U);
+  circuit->measure(0U, 0U);
+  circuit->measure(1U, 1U);
+
+  DeterministicNoiseSimulator simulator(std::move(circuit), std::string("A"),
+                                        0., 0., 1.);
+  const auto counts = simulator.simulate(16U);
+
+  EXPECT_EQ(counts, (std::map<std::string, std::size_t>{{"10", 16U}}));
+  EXPECT_EQ(simulator.additionalStatistics().at("single_shots"), "16");
+
+  EXPECT_EQ(simulator.simulate(16U), counts);
+  EXPECT_EQ(simulator.additionalStatistics().at("single_shots"), "32");
+  const auto& roots = simulator.dd->getRootSet<dd::mNode>();
+  ASSERT_EQ(roots.size(), 1U);
+  EXPECT_EQ(roots.begin()->second, 1U);
+}


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Consolidate duplicated DD circuit execution as part of
munich-quantum-toolkit/core#2103:

- delegate the exact, uncustomized `CircuitSimulator` path to MQT Core's shared
  execution kernel;
- retain DDSIM's hook-based path for derived and approximation-enabled
  simulators;
- preserve ordered measurement semantics and correct DD-root ownership across
  repeated and failed simulations; and
- provide `mqt.ddsim.sample` and `mqt.ddsim.simulate_statevector` as the new home
  of MQT Core's former high-level helpers.

The deterministic-noise simulator now also releases replaced density roots
between runs. Documentation, migration guidance, and regression tests cover
static and dynamic circuits, repeated measurements and jobs, RNG continuation,
specialized simulator hooks, failure recovery, and the Python helpers.

Part of munich-quantum-toolkit/core#2103

## Dependencies and merge order

This PR is stacked on #977 and therefore targets
`codex/core-v4-circuit-optimizer`. It also depends on
munich-quantum-toolkit/core#2273, which introduces the result-bearing
`dd::sample` API.

The Core version requirement and lock file intentionally remain unchanged while
Core v4 is unreleased. Keep this PR as a draft until Core v4 is available, #977
is resolved, the dependency metadata is updated, and the complete test suite
passes against the released dependency.

## Validation

- 9/9 focused C++ circuit-execution regression tests
- 10/10 Python helper tests against the rebuilt DDSIM extension
- full `uvx nox -s lint`
- `git diff --check`

The complete default suite and CI require the future Core v4 dependency pin.

## AI assistance

Codex materially assisted with implementation, validation, review, and this pull
request description. A human must review and understand the changes before
marking this pull request ready.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks. Full validation awaits the released Core v4 dependency.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/ddsim/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
